### PR TITLE
Fix git version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.15.3-alpine3.12
 
-RUN apk add --no-cache git~=2.24
+RUN apk add --no-cache git~=2.26
 
 RUN go get github.com/schrej/godacov
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-alpine
+FROM golang:1.15.3-alpine3.12
 
 RUN apk add --no-cache git~=2.24
 


### PR DESCRIPTION
Hey @brpaz,

Thanks for taking care of this gh action.
Nonetheless I'm running into an issue regarding this one:
![image](https://user-images.githubusercontent.com/3816424/96187792-e8515c80-0f3d-11eb-89e6-f5c77ed0935c.png)

I've seen you already had this issue before, I think using a pinned version of `golang-alpine` will prevent having this kind of problem.

Best!